### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,26 +7,26 @@
 #######################################
 
 TimeFormater	KEYWORD1
-Seconds			KEYWORD1
+Seconds	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
 
-PrintHHMMSS			KEYWORD2			
-numberOfSeconds		KEYWORD2
-numberOfMinutes		KEYWORD2
-numberOfHours		KEYWORD2
-PrintDigit			KEYWORD2
-printer				KEYWORD2
+PrintHHMMSS	KEYWORD2
+numberOfSeconds	KEYWORD2
+numberOfMinutes	KEYWORD2
+numberOfHours	KEYWORD2
+PrintDigit	KEYWORD2
+printer	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-SECS_PER_MIN 	LITERAL1
+SECS_PER_MIN	LITERAL1
 SECS_PER_HOUR	LITERAL1
-SECS_PER_DAY 	LITERAL1
+SECS_PER_DAY	LITERAL1
 
 #######################################


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords